### PR TITLE
Fix installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
In https://github.com/conda-forge/staged-recipes/pull/15101 the installation on Windows was found to fail with this traceback:

```python
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\VssAdministrator\AppData\Local\Temp\pip-req-build-ekbg1mnz\setup.py", line 6, in <module>
        long_description = fh.read()
      File "C:\Miniconda\conda-bld\py-readability-metrics_1622551267782\_h_env\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 7942: character maps to <undefined>
WARNING: Discarding file:///C:/Miniconda/conda-bld/py-readability-metrics_1622551267782/work. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

This PR fixes the issue by ensuring UTF-8 is used instead of relying on the system default.