### PR TITLE
Short texts raise warning instead of error | fix #14

### DIFF
--- a/readability/exceptions/__init__.py
+++ b/readability/exceptions/__init__.py
@@ -1,2 +1,8 @@
+from warnings import warn
+
+
 class ReadabilityException(Exception):
     pass
+
+def minimum_words_warning():
+    warn('100 words required for optimal accuracy.')

--- a/readability/scorers/ari.py
+++ b/readability/scorers/ari.py
@@ -1,5 +1,5 @@
 import math
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -17,7 +17,7 @@ class ARI:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/coleman_liau.py
+++ b/readability/scorers/coleman_liau.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -15,7 +15,7 @@ class ColemanLiau:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/dale_chall.py
+++ b/readability/scorers/dale_chall.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -15,7 +15,7 @@ class DaleChall:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/flesch.py
+++ b/readability/scorers/flesch.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -16,7 +16,7 @@ class Flesch:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/flesch_kincaid.py
+++ b/readability/scorers/flesch_kincaid.py
@@ -1,5 +1,4 @@
-from readability.exceptions import ReadabilityException
-
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 class Result:
     def __init__(self, score, grade_level):
@@ -15,7 +14,7 @@ class FleschKincaid:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/gunning_fog.py
+++ b/readability/scorers/gunning_fog.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -15,7 +15,7 @@ class GunningFog:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/linsear_write.py
+++ b/readability/scorers/linsear_write.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -15,7 +15,7 @@ class LinsearWrite:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()

--- a/readability/scorers/spache.py
+++ b/readability/scorers/spache.py
@@ -1,4 +1,4 @@
-from readability.exceptions import ReadabilityException
+from readability.exceptions import ReadabilityException, minimum_words_warning
 
 
 class Result:
@@ -15,7 +15,7 @@ class Spache:
     def __init__(self, stats):
         self._stats = stats
         if stats.num_words < 100:
-            raise ReadabilityException('100 words required.')
+            minimum_words_warning()
 
     def score(self):
         score = self._score()


### PR DESCRIPTION
Here is my workaround to be able to measure readability on texts that have less than 100 words.